### PR TITLE
Fix export columns

### DIFF
--- a/src/components/DataPreview.tsx
+++ b/src/components/DataPreview.tsx
@@ -70,7 +70,7 @@ export const DataPreview: React.FC<DataPreviewProps> = ({ data }) => {
                   </td>
                   <td className="px-6 py-4">
                     <div className="text-sm text-slate-900">
-                      {location['Ligne d\'adresse 1']}
+                      {location["Ligne d'adresse\u00a01"]}
                     </div>
                     <div className="text-sm text-slate-500">
                       {location['Localité']}, {location['Code postal']}
@@ -177,7 +177,7 @@ export const DataPreview: React.FC<DataPreviewProps> = ({ data }) => {
                 <div>
                   <h4 className="font-medium text-slate-900 mb-3">Adresse</h4>
                   <div className="text-sm space-y-1">
-                    <p>{selectedLocation['Ligne d\'adresse 1']}</p>
+                      <p>{selectedLocation["Ligne d'adresse\u00a01"]}</p>
                     <p>{selectedLocation['Localité']}, {selectedLocation['Code postal']}</p>
                     <p>{selectedLocation['Pays/Région']}</p>
                   </div>
@@ -216,10 +216,10 @@ export const DataPreview: React.FC<DataPreviewProps> = ({ data }) => {
                 </div>
 
                 {/* Description */}
-                {selectedLocation['Description fournie par l\'établissement'] && (
+                {selectedLocation["Fournie par l'établissement"] && (
                   <div>
                     <h4 className="font-medium text-slate-900 mb-3">Description</h4>
-                    <p className="text-sm text-slate-600">{selectedLocation['Description fournie par l\'établissement']}</p>
+                    <p className="text-sm text-slate-600">{selectedLocation["Fournie par l'établissement"]}</p>
                   </div>
                 )}
               </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,33 +35,52 @@ export interface MondialRelayData {
   'Heure Fin 1ère Période Dimanche': string;
   'Heure Début 2ème Période Dimanche': string;
   'Heure Fin 2ème Période Dimanche': string;
-  [key: string]: any;
+  [key: string]: string | number | undefined;
 }
 
 // French GMB template structure - exact column names from the template
 export interface GMBData {
   'Code de magasin': string;
-  'Nom de l\'entreprise': string;
-  'Ligne d\'adresse 1': string;
-  'Ligne d\'adresse 2': string;
+  "Nom de l'entreprise": string;
+  "Ligne d'adresse\u00a01": string;
+  "Ligne d'adresse\u00a02": string;
+  "Ligne d'adresse\u00a03": string;
+  "Ligne d'adresse\u00a04": string;
+  "Ligne d'adresse\u00a05": string;
+  'Sous-localité': string;
   'Localité': string;
   'Région administrative': string;
-  'Code postal': string;
   'Pays/Région': string;
+  'Code postal': string;
   'Latitude': number;
   'Longitude': number;
+  'Numéro principal': string;
+  'Autres numéros de téléphone': string;
+  'Site Web': string;
   'Catégorie principale': string;
   'Catégories supplémentaires': string;
-  'Site Web': string;
-  'Téléphone': string;
-  'Description fournie par l\'établissement': string;
+  'Horaires le dimanche': string;
   'Horaires le lundi': string;
   'Horaires le mardi': string;
   'Horaires le mercredi': string;
   'Horaires le jeudi': string;
   'Horaires le vendredi': string;
   'Horaires le samedi': string;
-  'Horaires le dimanche': string;
+  "Horaires d'ouverture exceptionnels": string;
+  "Fournie par l'établissement": string;
+  'Date de création': string;
+  'Photo du logo': string;
+  'Photo de couverture': string;
+  'Autres photos': string;
+  'Libellés': string;
+  'Numéro de téléphone pour les extensions de lieu AdWords': string;
+  "Fournis par l'établissement: S'identifie comme géré par une femme (is_owned_by_women)": string;
+  'Paiements: Cartes de crédit (pay_credit_card_types_accepted): American Express (american_express)': string;
+  'Paiements: Cartes de crédit (pay_credit_card_types_accepted): MasterCard (mastercard)': string;
+  'Paiements: Cartes de crédit (pay_credit_card_types_accepted): VISA (visa)': string;
+  'Services: Wi-Fi (wi_fi)': string;
+  'URL des pages Google\u00a0Adresses: Lien du menu ou des services (url_menu)': string;
+  "URL des pages Google\u00a0Adresses: Liens pour commander à l'avance (url_order_ahead)": string;
 }
 
 export interface GlobalInputsType {

--- a/src/utils/excelExporter.ts
+++ b/src/utils/excelExporter.ts
@@ -10,27 +10,46 @@ export const exportToGMBExcel = (data: GMBData[]): Promise<void> => {
       // Define the exact column order from the French GMB template
       const columnOrder = [
         'Code de magasin',
-        'Nom de l\'entreprise',
-        'Ligne d\'adresse 1',
-        'Ligne d\'adresse 2',
+        "Nom de l'entreprise",
+        "Ligne d'adresse\u00a01",
+        "Ligne d'adresse\u00a02",
+        "Ligne d'adresse\u00a03",
+        "Ligne d'adresse\u00a04",
+        "Ligne d'adresse\u00a05",
+        'Sous-localité',
         'Localité',
         'Région administrative',
-        'Code postal',
         'Pays/Région',
+        'Code postal',
         'Latitude',
         'Longitude',
+        'Numéro principal',
+        'Autres numéros de téléphone',
+        'Site Web',
         'Catégorie principale',
         'Catégories supplémentaires',
-        'Site Web',
-        'Téléphone',
-        'Description fournie par l\'établissement',
+        'Horaires le dimanche',
         'Horaires le lundi',
         'Horaires le mardi',
         'Horaires le mercredi',
         'Horaires le jeudi',
         'Horaires le vendredi',
         'Horaires le samedi',
-        'Horaires le dimanche'
+        "Horaires d'ouverture exceptionnels",
+        "Fournie par l'établissement",
+        'Date de création',
+        'Photo du logo',
+        'Photo de couverture',
+        'Autres photos',
+        'Libellés',
+        'Numéro de téléphone pour les extensions de lieu AdWords',
+        "Fournis par l'établissement: S'identifie comme géré par une femme (is_owned_by_women)",
+        'Paiements: Cartes de crédit (pay_credit_card_types_accepted): American Express (american_express)',
+        'Paiements: Cartes de crédit (pay_credit_card_types_accepted): MasterCard (mastercard)',
+        'Paiements: Cartes de crédit (pay_credit_card_types_accepted): VISA (visa)',
+        'Services: Wi-Fi (wi_fi)',
+        'URL des pages Google\u00a0Adresses: Lien du menu ou des services (url_menu)',
+        "URL des pages Google\u00a0Adresses: Liens pour commander à l'avance (url_order_ahead)"
       ];
       
       // Create header row
@@ -46,30 +65,7 @@ export const exportToGMBExcel = (data: GMBData[]): Promise<void> => {
       const ws = XLSX.utils.aoa_to_sheet(wsData);
       
       // Set column widths for better readability
-      const colWidths = [
-        { wch: 15 }, // Code de magasin
-        { wch: 30 }, // Nom de l'entreprise
-        { wch: 40 }, // Ligne d'adresse 1
-        { wch: 25 }, // Ligne d'adresse 2
-        { wch: 20 }, // Localité
-        { wch: 20 }, // Région administrative
-        { wch: 12 }, // Code postal
-        { wch: 15 }, // Pays/Région
-        { wch: 12 }, // Latitude
-        { wch: 12 }, // Longitude
-        { wch: 25 }, // Catégorie principale
-        { wch: 30 }, // Catégories supplémentaires
-        { wch: 30 }, // Site Web
-        { wch: 15 }, // Téléphone
-        { wch: 50 }, // Description fournie par l'établissement
-        { wch: 18 }, // Horaires le lundi
-        { wch: 18 }, // Horaires le mardi
-        { wch: 18 }, // Horaires le mercredi
-        { wch: 18 }, // Horaires le jeudi
-        { wch: 18 }, // Horaires le vendredi
-        { wch: 18 }, // Horaires le samedi
-        { wch: 18 }  // Horaires le dimanche
-      ];
+      const colWidths = columnOrder.map(() => ({ wch: 20 }));
       ws['!cols'] = colWidths;
       
       // Add worksheet to workbook

--- a/src/utils/excelProcessor.ts
+++ b/src/utils/excelProcessor.ts
@@ -15,7 +15,7 @@ export const processExcelFile = (file: File): Promise<MondialRelayData[]> => {
         const worksheet = workbook.Sheets[worksheetName];
         
         // Convert to JSON
-        const jsonData = XLSX.utils.sheet_to_json(worksheet, { header: 1 });
+        const jsonData: unknown[][] = XLSX.utils.sheet_to_json(worksheet, { header: 1 });
         
         if (jsonData.length < 2) {
           throw new Error('File appears to be empty or invalid');
@@ -42,12 +42,12 @@ export const processExcelFile = (file: File): Promise<MondialRelayData[]> => {
         
         // Convert rows to objects
         const processedData: MondialRelayData[] = [];
-        
+
         for (let i = 1; i < jsonData.length; i++) {
-          const row = jsonData[i] as any[];
+          const row = jsonData[i] as (string | number | undefined)[];
           if (row.length === 0) continue; // Skip empty rows
-          
-          const rowData: any = {};
+
+          const rowData: Record<string, string | number> = {};
           headers.forEach((header, index) => {
             rowData[header] = row[index] || '';
           });

--- a/src/utils/gmbConverter.ts
+++ b/src/utils/gmbConverter.ts
@@ -4,7 +4,7 @@ const formatTime = (time: string): string => {
   if (!time || time === '00:00:00' || time === '00:00') return '';
   
   // Handle different time formats
-  let cleanTime = time.trim();
+  const cleanTime = time.trim();
   
   // If it's already in HH:MM format, return as is
   if (/^\d{2}:\d{2}$/.test(cleanTime)) {
@@ -127,27 +127,46 @@ export const convertToGMBFormat = (
     // Return data using exact French GMB column names
     return {
       'Code de magasin': location['Numéro Relais'] || '',
-      'Nom de l\'entreprise': location['Enseigne'] || '',
-      'Ligne d\'adresse 1': location['Adresse1'] || '',
-      'Ligne d\'adresse 2': '', // Not provided in Mondial Relay data
+      "Nom de l'entreprise": location['Enseigne'] || '',
+      "Ligne d'adresse\u00a01": location['Adresse1'] || '',
+      "Ligne d'adresse\u00a02": '',
+      "Ligne d'adresse\u00a03": '',
+      "Ligne d'adresse\u00a04": '',
+      "Ligne d'adresse\u00a05": '',
+      'Sous-localité': '',
       'Localité': location['Ville'] || '',
-      'Région administrative': '', // Not provided in Mondial Relay data
+      'Région administrative': '',
+      'Pays/Région': 'France',
       'Code postal': location['Code Postal'] || '',
-      'Pays/Région': 'France', // Default for Mondial Relay
       'Latitude': parseFloat(location['Latitude']) || 0,
       'Longitude': parseFloat(location['Longitude']) || 0,
+      'Numéro principal': '',
+      'Autres numéros de téléphone': '',
+      'Site Web': '',
       'Catégorie principale': globalInputs.serviceType,
-      'Catégories supplémentaires': '', // Not provided
-      'Site Web': '', // Not provided in Mondial Relay data
-      'Téléphone': '', // Not provided in Mondial Relay data
-      'Description fournie par l\'établissement': globalInputs.description,
+      'Catégories supplémentaires': '',
+      'Horaires le dimanche': sundayHours,
       'Horaires le lundi': mondayHours,
       'Horaires le mardi': tuesdayHours,
       'Horaires le mercredi': wednesdayHours,
       'Horaires le jeudi': thursdayHours,
       'Horaires le vendredi': fridayHours,
       'Horaires le samedi': saturdayHours,
-      'Horaires le dimanche': sundayHours
+      "Horaires d'ouverture exceptionnels": '',
+      "Fournie par l'établissement": globalInputs.description,
+      'Date de création': '',
+      'Photo du logo': '',
+      'Photo de couverture': '',
+      'Autres photos': '',
+      'Libellés': '',
+      'Numéro de téléphone pour les extensions de lieu AdWords': '',
+      "Fournis par l'établissement: S'identifie comme géré par une femme (is_owned_by_women)": '',
+      'Paiements: Cartes de crédit (pay_credit_card_types_accepted): American Express (american_express)': '',
+      'Paiements: Cartes de crédit (pay_credit_card_types_accepted): MasterCard (mastercard)': '',
+      'Paiements: Cartes de crédit (pay_credit_card_types_accepted): VISA (visa)': '',
+      'Services: Wi-Fi (wi_fi)': '',
+      'URL des pages Google\u00a0Adresses: Lien du menu ou des services (url_menu)': '',
+      "URL des pages Google\u00a0Adresses: Liens pour commander à l'avance (url_order_ahead)": ''
     };
   });
 };


### PR DESCRIPTION
## Summary
- sync exported XLSX columns with official Google template
- use non-breaking spaces and rename description column
- update conversion logic and preview accordingly
- tighten types for Excel processing

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6846c300a1908324aad67fff41589b71