### PR TITLE
Fix SEO optimizer template behavior

### DIFF
--- a/src/utils/seoOptimizer.ts
+++ b/src/utils/seoOptimizer.ts
@@ -37,6 +37,10 @@ export const optimizeSeo = (
   options: SeoOptions
 ): GMBData[] => {
   return data.map((item) => {
+    if (!options.template.trim()) {
+      return { ...item };
+    }
+
     let name = options.template;
 
     name = replaceToken(name, '{Ville}', item['Localité'] || '', options.includeCity);


### PR DESCRIPTION
## Summary
- prevent SEO optimization from removing store names when the template is blank

## Testing
- `npm install --omit=dev`
- `npm run lint` *(fails: ESLint couldn't find a configuration file due to missing dev dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847fe12bc588324a8e90868216c37e3