### PR TITLE
Fix SEO optimizer template behavior

### DIFF
--- a/src/components/SeoTab.tsx
+++ b/src/components/SeoTab.tsx
@@ -3,6 +3,7 @@ import { GMBData } from '../types';
 import { readGMBExcel } from '../utils/gmbExcelReader';
 import { exportToGMBExcel } from '../utils/excelExporter';
 import { optimizeSeo, SeoOptions } from '../utils/seoOptimizer';
+import { removeAccentsFromData } from '../utils/diacritic';
 
 export const SeoTab: React.FC = () => {
   const [originalData, setOriginalData] = useState<GMBData[]>([]);
@@ -46,6 +47,11 @@ export const SeoTab: React.FC = () => {
 
   const handleExport = async () => {
     await exportToGMBExcel(optimizedData, 'gmb_seo_optimized');
+  };
+
+  const handleRemoveAccents = () => {
+    setOriginalData(prev => removeAccentsFromData(prev));
+    setOptimizedData(prev => removeAccentsFromData(prev));
   };
 
   return (
@@ -106,6 +112,13 @@ export const SeoTab: React.FC = () => {
             <span>Capitaliser la première lettre de chaque mot</span>
           </label>
         </div>
+        <button
+          onClick={handleRemoveAccents}
+          disabled={originalData.length === 0}
+          className="px-6 py-3 bg-purple-600 text-white font-medium rounded-lg hover:bg-purple-700 disabled:opacity-50"
+        >
+          Supprimer les accents du fichier
+        </button>
         <button
           onClick={handleOptimize}
           disabled={isProcessing || originalData.length === 0}

--- a/src/utils/diacritic.ts
+++ b/src/utils/diacritic.ts
@@ -1,0 +1,12 @@
+export const removeAccents = (str: string): string =>
+  str.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+
+export const removeAccentsFromData = <T extends Record<string, unknown>>(data: T[]): T[] =>
+  data.map(item => {
+    const cleanItem: Record<string, unknown> = {};
+    Object.keys(item).forEach(key => {
+      const value = item[key];
+      cleanItem[key] = typeof value === 'string' ? removeAccents(value) : value;
+    });
+    return cleanItem as T;
+  });

--- a/src/utils/seoOptimizer.ts
+++ b/src/utils/seoOptimizer.ts
@@ -37,6 +37,10 @@ export const optimizeSeo = (
   options: SeoOptions
 ): GMBData[] => {
   return data.map((item) => {
+    if (!options.template.trim()) {
+      return { ...item };
+    }
+
     let name = options.template;
 
     name = replaceToken(name, '{Ville}', item['Localité'] || '', options.includeCity);


### PR DESCRIPTION
## Summary
- prevent SEO optimization from removing store names when the template is blank
- add a button to strip accents from imported GMB files

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847fe12bc588324a8e90868216c37e3