### PR TITLE
Fix brand mapping for Mondial Relay data

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export interface MondialRelayData {
   'Numéro TouchPoint': string;
   'Intitulé TouchPoint': string;
+  'Enseigne': string;
   'Adresse1': string;
   'Ville': string;
   'Code Postal': string;

--- a/src/utils/excelProcessor.ts
+++ b/src/utils/excelProcessor.ts
@@ -27,7 +27,7 @@ export const processExcelFile = (file: File): Promise<MondialRelayData[]> => {
         // Validate required columns
         const requiredColumns = [
           'Numéro TouchPoint',
-          'Intitulé TouchPoint',
+          'Enseigne',
           'Adresse1',
           'Ville',
           'Code Postal',

--- a/src/utils/gmbConverter.ts
+++ b/src/utils/gmbConverter.ts
@@ -127,7 +127,7 @@ export const convertToGMBFormat = (
     // Return data using exact French GMB column names
     return {
       'Code de magasin': location['Numéro TouchPoint'] || '',
-      "Nom de l'entreprise": location['Intitulé TouchPoint'] || '',
+      "Nom de l'entreprise": location['Enseigne'] || location['Intitulé TouchPoint'] || '',
       "Ligne d'adresse\u00a01": location['Adresse1'] || '',
       "Ligne d'adresse\u00a02": '',
       "Ligne d'adresse\u00a03": '',


### PR DESCRIPTION
## Summary
- require `Enseigne` column when reading Mondial Relay exports
- use `Enseigne` for the GMB store name
- document new `Enseigne` field in types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848257ba49c8324ae9d019ded660942